### PR TITLE
Cannot add permissions within <activity>

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -93,8 +93,6 @@ SOFTWARE.
         </js-module>
 
         <config-file target="AndroidManifest.xml" parent="/manifest/application/activity">
-            <!-- Open With  -->
-            <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
             <intent-filter>
                 <!-- category android:name="android.intent.category.BROWSABLE" / -->
                 <!-- See https://developer.android.com/guide/topics/manifest/data-element.html -->


### PR DESCRIPTION
AFAIK, it's not valid to use \<uses-permission> within an \<activity>.  I'm not sure why this plugin needs to add this permission, but if it really does, it should live in parent="/*" 
  