### PR TITLE
Wrong plist format. It should be <key>...</key><string>...</string>

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -64,9 +64,9 @@ SOFTWARE.
         <config-file target="*-Info.plist" parent="CFBundleURLTypes">
             <array>
                 <dict>
-                    <string>CFBundleURLName</string>
+                    <key>CFBundleURLName</key>
                     <string>cc.fovea.openwith.$IOS_URL_SCHEME.shareextension</string>
-                    <string>CFBundleURLSchemes</string>
+                    <key>CFBundleURLSchemes</key>
                     <array>
                         <string>$IOS_URL_SCHEME</string>
                     </array>


### PR DESCRIPTION
plist fragment was bad formatted, it should follow <key></key><string></string> pattern to be parseable