### PR TITLE
Fix VIEW intents not received on js side

### DIFF
--- a/src/android/cc/fovea/openwith/Serializer.java
+++ b/src/android/cc/fovea/openwith/Serializer.java
@@ -37,6 +37,9 @@ class Serializer {
         if (items == null || items.length() == 0) {
             items = itemsFromExtras(contentResolver, intent.getExtras());
         }
+        if (items == null || items.length() == 0) {
+            items = itemsFromData(contentResolver, intent.getData());
+        }
         if (items == null) {
             return null;
         }
@@ -98,6 +101,27 @@ class Serializer {
         final JSONObject item = toJSONObject(
                 contentResolver,
                 (Uri) extras.get(Intent.EXTRA_STREAM));
+        if (item == null) {
+            return null;
+        }
+        final JSONObject[] items = new JSONObject[1];
+        items[0] = item;
+        return new JSONArray(items);
+    }
+
+    /** Extract the list of items from the intent's getData
+     *
+     * See Intent.ACTION_VIEW for details. */
+    public static JSONArray itemsFromData(
+            final ContentResolver contentResolver,
+            final Uri uri)
+            throws JSONException {
+        if (uri == null) {
+            return null;
+        }
+        final JSONObject item = toJSONObject(
+                contentResolver,
+                uri);
         if (item == null) {
             return null;
         }


### PR DESCRIPTION
Hi,

Thank you for your cordova plugin!

I am sending this PR to fix the following issue:
VIEW intents cannot be received on JS side because no item can be extracted from the intent.

According to https://developer.android.com/reference/android/content/Intent.html#ACTION_VIEW, in case of a VIEW intent, the URI has to be extracted from getData.

Thank you!
Best regards!