### PR TITLE
Refactor use of requireCordovaModule for cordova-lib 9.0.0

### DIFF
--- a/hooks/iosAddTarget.js
+++ b/hooks/iosAddTarget.js
@@ -107,13 +107,13 @@ function getCordovaParameter(configXml, variableName) {
 
 // Get the bundle id from config.xml
 // function getBundleId(context, configXml) {
-//   var elementTree = context.requireCordovaModule('elementtree');
+//   var elementTree = require('elementtree');
 //   var etree = elementTree.parse(configXml);
 //   return etree.getroot().get('id');
 // }
 
 function parsePbxProject(context, pbxProjectPath) {
-  var xcode = context.requireCordovaModule('xcode');
+  var xcode = require('xcode');
   console.log('    Parsing existing project at location: ' + pbxProjectPath + '...');
   var pbxProject;
   if (context.opts.cordova.project) {
@@ -212,7 +212,7 @@ console.log('Adding target "' + PLUGIN_ID + '/ShareExtension" to XCode project')
 
 module.exports = function (context) {
 
-  var Q = context.requireCordovaModule('q');
+  var Q = require('q');
   var deferral = new Q.defer();
 
   // if (context.opts.cordova.platforms.indexOf('ios') < 0) {

--- a/hooks/iosCopyShareExtension.js
+++ b/hooks/iosCopyShareExtension.js
@@ -116,7 +116,7 @@ function findXCodeproject(context, callback) {
 }
 
 module.exports = function(context) {
-  var Q = context.requireCordovaModule('q');
+  var Q = require('q');
   var deferral = new Q.defer();
 
   findXCodeproject(context, function(projectFolder, projectName) {

--- a/hooks/iosRemoveTarget.js
+++ b/hooks/iosRemoveTarget.js
@@ -74,7 +74,7 @@ function iosFolder(context) {
 }
 
 function parsePbxProject(context, pbxProjectPath) {
-  var xcode = context.requireCordovaModule('xcode');
+  var xcode = require('xcode');
   console.log('    Parsing existing project at location: ' + pbxProjectPath + '...');
   var pbxProject;
   if (context.opts.cordova.project) {
@@ -125,7 +125,7 @@ console.log('Removing target "' + PLUGIN_ID + '/ShareExtension" to XCode project
 
 module.exports = function (context) {
 
-  var Q = context.requireCordovaModule('q');
+  var Q = require('q');
   var deferral = new Q.defer();
 
   findXCodeproject(context, function(projectFolder, projectName) {

--- a/hooks/npmInstall.js
+++ b/hooks/npmInstall.js
@@ -21,8 +21,8 @@
 const PLUGIN_ID = "cc.fovea.cordova.openwith";
 
 module.exports = function (context) {
-    var child_process = context.requireCordovaModule('child_process');
-    var deferral = context.requireCordovaModule('q').defer();
+    var child_process = require('child_process');
+    var deferral = require('q').defer();
 
     console.log('Installing "' + PLUGIN_ID + '" dependencies');
     child_process.exec('npm install --production', {cwd:__dirname}, function (error) {


### PR DESCRIPTION
'requireCordovaModule' is now deprecated. 

See similiar issue and solution: https://github.com/GEDYSIntraWare/cordova-plugin-call-directory/issues/13 -> Thanks @tombell