### PR TITLE
Fix extension crash on iOS 13

### DIFF
--- a/src/ios/ShareExtension/ShareViewController.m
+++ b/src/ios/ShareExtension/ShareViewController.m
@@ -88,7 +88,8 @@
             NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:methodSignature];
 
             // Arguments
-            NSDictionary<NSString *, id> *options = [NSDictionary dictionary];
+            UISceneOpenExternalURLOptions * options = [UISceneOpenExternalURLOptions alloc];
+            options.universalLinksOnly = false;
             void (^completion)(BOOL success) = ^void(BOOL success) {
                 NSLog(@"Completions block: %i", success);
             };

--- a/src/ios/ShareExtension/ShareViewController.m
+++ b/src/ios/ShareExtension/ShareViewController.m
@@ -88,7 +88,7 @@
             NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:methodSignature];
 
             // Arguments
-            UISceneOpenExternalURLOptions * options = [UISceneOpenExternalURLOptions alloc];
+            UISceneOpenExternalURLOptions * options = [[UISceneOpenExternalURLOptions alloc] init];
             options.universalLinksOnly = false;
             void (^completion)(BOOL success) = ^void(BOOL success) {
                 NSLog(@"Completions block: %i", success);

--- a/src/ios/ShareExtension/ShareViewController.m
+++ b/src/ios/ShareExtension/ShareViewController.m
@@ -88,19 +88,31 @@
             NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:methodSignature];
 
             // Arguments
-            UISceneOpenExternalURLOptions * options = [[UISceneOpenExternalURLOptions alloc] init];
-            options.universalLinksOnly = false;
             void (^completion)(BOOL success) = ^void(BOOL success) {
                 NSLog(@"Completions block: %i", success);
             };
-
-            [invocation setTarget: responder];
-            [invocation setSelector: selector];
-            [invocation setArgument: &url atIndex: 2];
-            [invocation setArgument: &options atIndex:3];
-            [invocation setArgument: &completion atIndex: 4];
-            [invocation invoke];
-            break;
+            if (@available(iOS 13.0, *)) {
+                UISceneOpenExternalURLOptions * options = [[UISceneOpenExternalURLOptions alloc] init];
+                options.universalLinksOnly = false;
+                
+                [invocation setTarget: responder];
+                [invocation setSelector: selector];
+                [invocation setArgument: &url atIndex: 2];
+                [invocation setArgument: &options atIndex:3];
+                [invocation setArgument: &completion atIndex: 4];
+                [invocation invoke];
+                break;
+            } else {
+                NSDictionary<NSString *, id> *options = [NSDictionary dictionary];
+                
+                [invocation setTarget: responder];
+                [invocation setSelector: selector];
+                [invocation setArgument: &url atIndex: 2];
+                [invocation setArgument: &options atIndex:3];
+                [invocation setArgument: &completion atIndex: 4];
+                [invocation invoke];
+                break;
+            }
         }
     }
 }


### PR DESCRIPTION
Changing the options seems to fix the crash on iOS 13. Then strange thing is that this seems to work on iOS 12 aswell when built with Xcode 11. Working with `@available`and the old option did not work for me and now it shows warnings because the new optiosn are on iOS 13 only. No idea why.

This "fix" needs Xcode 11 so we should wait before merging this to a new version.

Fixes #67 