### PR TITLE
change hook triggering iosAddTarget.js.

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -76,7 +76,7 @@ SOFTWARE.
 
         <hook type="before_plugin_install" src="hooks/npmInstall.js" />
         <hook type="before_plugin_install" src="hooks/iosCopyShareExtension.js" />
-        <hook type="after_plugin_install" src="hooks/iosAddTarget.js" />
+        <hook type="after_plugin_add" src="hooks/iosAddTarget.js" />
         <hook type="before_plugin_uninstall" src="hooks/iosRemoveTarget.js" />
 
         <framework src="MobileCoreServices.framework" />


### PR DESCRIPTION
Problem: If the plugin is already installed, iosAddTarget.js will not be triggered. You have to remove and re add the plugin each times.

These issues are related:
https://github.com/j3k0/cordova-plugin-openwith/issues/60
https://github.com/EternallLight/cordova-plugin-openwith-ios/issues/19

Solution, change hook from **after_plugin_install** to **after_plugin_add** which is triggered even if the plugin is already installed