### PR TITLE
Android only version

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,8 @@ On the Cordova App side, the plugin checks listens for app start or resume event
 Here's the promised one liner:
 
 ```
-cordova plugin add cc.fovea.cordova.openwith \
-  --variable ANDROID_MIME_TYPE="image/*" \
-  --variable IOS_URL_SCHEME=ccfoveaopenwithdemo \
-  --variable IOS_UNIFORM_TYPE_IDENTIFIER=public.image
+cordova plugin add cc.fovea.cordova.openwith.android \
+  --variable ANDROID_MIME_TYPE="image/*"
 ```
 
 | variable | example | notes |
@@ -83,7 +81,7 @@ Use the `ANDROID_EXTRA_ACTIONS` to accept additional actions. The variable shoul
 
 ```
 MY_EXTRA_ACTIONS='<action android:name="android.intent.action.VIEW" />'
-cordova plugin add cc.fovea.cordova.openwith \
+cordova plugin add cc.fovea.cordova.openwith.android \
   --variable ANDROID_MIME_TYPE="image/*" \
   --variable "ANDROID_EXTRA_ACTIONS=$MY_EXTRA_ACTIONS"
 ```

--- a/package.json
+++ b/package.json
@@ -1,12 +1,11 @@
 {
-  "name": "cc.fovea.cordova.openwith",
+  "name": "cc.fovea.cordova.openwith.android",
   "version": "2.0.0",
   "description": "Cordova \"Open With\" plugin for iOS and Android",
   "cordova": {
-    "id": "cc.fovea.cordova.openwith",
+    "id": "cc.fovea.cordova.openwith.android",
     "platforms": [
-      "android",
-      "ios"
+      "android"
     ]
   },
   "repository": {
@@ -16,11 +15,9 @@
   "keywords": [
     "ecosystem:cordova",
     "cordova-android",
-    "cordova-ios",
     "cordova",
     "phonegap",
     "openwith",
-    "ios",
     "android"
   ],
   "scripts": {
@@ -65,18 +62,8 @@
     "src/android/cc/fovea/openwith/OpenWithPlugin.java",
     "src/android/cc/fovea/openwith/PluginResultSender.java",
     "src/android/cc/fovea/openwith/Serializer.java",
-    "src/ios/OpenWithPlugin.m",
-    "src/ios/ShareExtension/MainInterface.storyboard",
-    "src/ios/ShareExtension/ShareExtension-Entitlements.plist",
-    "src/ios/ShareExtension/ShareExtension-Info.plist",
-    "src/ios/ShareExtension/ShareViewController.h",
-    "src/ios/ShareExtension/ShareViewController.m",
     "www/openwith.js",
     "www/test-openwith.js",
-    "hooks/iosAddTarget.js",
-    "hooks/iosRemoveTarget.js",
-    "hooks/iosCopyShareExtension.js",
-    "hooks/npmInstall.js",
     "install-pmd",
     "plugin.xml",
     "LICENSE",

--- a/plugin.xml
+++ b/plugin.xml
@@ -25,11 +25,11 @@ SOFTWARE.
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
-    id="cc.fovea.cordova.openwith"
+    id="cc.fovea.cordova.openwith.android"
     version="2.0.0">
 
     <name>OpenWith</name>
-	<description>Cordova "Open With" plugin for iOS and Android</description>
+	<description>Cordova "Open With" plugin for Android</description>
     <engines>
         <engine name="cordova" version=">=6.0.0" />
     </engines>
@@ -37,50 +37,7 @@ SOFTWARE.
     <issue>https://github.com/j3k0/cordova-plugin-openwith/issues</issue>
 
 	<license>MIT</license>
-    <keywords>cordova,phonegap,openwith,ios,android</keywords>
-
-    <!-- ios -->
-    <platform name="ios">
-        <preference name="IOS_URL_SCHEME" />
-        <preference name="IOS_UNIFORM_TYPE_IDENTIFIER" />
-
-        <js-module src="www/openwith.js" name="openwith">
-            <clobbers target="cordova.openwith" />
-        </js-module>
-
-        <!-- Cordova 2.2 -->
-        <plugins-plist key="OpenWith" string="OpenWith" />
-
-        <!-- Cordova 2.5+ -->
-        <config-file target="config.xml" parent="/*">
-            <feature name="OpenWithPlugin">
-                <param name="ios-package" value="OpenWithPlugin" />
-                <param name="onload" value="true" />
-            </feature>
-        </config-file>
-
-        <source-file src="src/ios/OpenWithPlugin.m" />
-
-        <config-file target="*-Info.plist" parent="CFBundleURLTypes">
-            <array>
-                <dict>
-                    <key>CFBundleURLName</key>
-                    <string>cc.fovea.openwith.$IOS_URL_SCHEME.shareextension</string>
-                    <key>CFBundleURLSchemes</key>
-                    <array>
-                        <string>$IOS_URL_SCHEME</string>
-                    </array>
-                </dict>
-            </array>
-        </config-file>
-
-        <hook type="before_plugin_install" src="hooks/npmInstall.js" />
-        <hook type="before_prepare" src="hooks/iosCopyShareExtension.js" />
-        <hook type="after_prepare" src="hooks/iosAddTarget.js" />
-        <hook type="before_plugin_uninstall" src="hooks/iosRemoveTarget.js" />
-
-        <framework src="MobileCoreServices.framework" />
-    </platform>
+    <keywords>cordova,phonegap,openwith,android</keywords>
 
     <!-- android -->
     <platform name="android">
@@ -109,7 +66,7 @@ SOFTWARE.
         <config-file target="res/xml/config.xml" parent="/*">
             <feature name="OpenWithPlugin">
 				<param name="android-package" value="cc.fovea.openwith.OpenWithPlugin"/>
-			</feature>
+            </feature>
             <preference name="AndroidLaunchMode" value="singleTask"/>
         </config-file>
 


### PR DESCRIPTION
This plugin might also be useful when other solutions are used on iOS (for example's cordova's built-in [handleOpenURL](https://github.com/apache/cordova-ios/blob/master/guides/Cordova%20Custom%20URL%20Scheme%20Handling.md)).

The user would not want to add the ShareExtension to the iOS version, thus this new branch in which ios is disabled.

Changed plugin ID to `cc.fovea.cordova.openwith.android`, will publish the android only version.