### PR TITLE
Fix missing copy

### DIFF
--- a/hooks/iosAddTarget.js
+++ b/hooks/iosAddTarget.js
@@ -124,7 +124,7 @@ function parsePbxProject(context, pbxProjectPath) {
 
 function forEachShareExtensionFile(context, callback) {
   var shareExtensionFolder = path.join(iosFolder(context), 'ShareExtension');
-  if (!fs.exists(shareExtensionFolder)) {
+  if (!fs.existsSync(shareExtensionFolder)) {
     console.error('!!  Shared extension files have not been copied yet!!');
     return;
   }

--- a/hooks/iosAddTarget.js
+++ b/hooks/iosAddTarget.js
@@ -320,6 +320,8 @@ module.exports = function (context) {
             if (productName.indexOf('ShareExt') >= 0) {
               buildSettingsObj['PROVISIONING_PROFILE'] = PROVISIONING_PROFILE;
               buildSettingsObj['DEVELOPMENT_TEAM'] = DEVELOPMENT_TEAM;
+              buildSettingsObj['CODE_SIGN_STYLE'] = 'Manual';
+              buildSettingsObj['CODE_SIGN_IDENTITY'] = 'iPhone Distribution';
               console.log('Added signing identities for extension!');
             }
           }

--- a/hooks/iosAddTarget.js
+++ b/hooks/iosAddTarget.js
@@ -124,6 +124,10 @@ function parsePbxProject(context, pbxProjectPath) {
 
 function forEachShareExtensionFile(context, callback) {
   var shareExtensionFolder = path.join(iosFolder(context), 'ShareExtension');
+  if (!fs.exists(shareExtensionFolder)) {
+    console.error('!!  Shared extension files have not been copied yet!!');
+    return;
+  }
   fs.readdirSync(shareExtensionFolder).forEach(function(name) {
     // Ignore junk files like .DS_Store
     if (!/^\..*/.test(name)) {

--- a/hooks/iosAddTarget.js
+++ b/hooks/iosAddTarget.js
@@ -321,7 +321,7 @@ module.exports = function (context) {
               buildSettingsObj['PROVISIONING_PROFILE'] = PROVISIONING_PROFILE;
               buildSettingsObj['DEVELOPMENT_TEAM'] = DEVELOPMENT_TEAM;
               buildSettingsObj['CODE_SIGN_STYLE'] = 'Manual';
-              buildSettingsObj['CODE_SIGN_IDENTITY'] = 'iPhone Distribution';
+              buildSettingsObj['CODE_SIGN_IDENTITY'] = '"iPhone Distribution"';
               console.log('Added signing identities for extension!');
             }
           }

--- a/plugin.xml
+++ b/plugin.xml
@@ -75,6 +75,7 @@ SOFTWARE.
         </config-file>
 
         <hook type="before_plugin_install" src="hooks/npmInstall.js" />
+        <hook type="after_plugin_install" src="hooks/iosCopyShareExtension.js" />
         <hook type="before_prepare" src="hooks/iosCopyShareExtension.js" />
         <hook type="after_prepare" src="hooks/iosAddTarget.js" />
         <hook type="before_plugin_uninstall" src="hooks/iosRemoveTarget.js" />


### PR DESCRIPTION
It seems that when the folders `plugins` and `platforms` do not exists (as is usually in a CI scenario) the copy script does not run. This seems like a bug in cordova, but I believe this simple workaround is currently enough.
This should address #82.