### PR TITLE
Fix #99: stop overwriting main target's CODE_SIGN_ENTITLEMENTS

### DIFF
--- a/hooks/iosAddTarget.js
+++ b/hooks/iosAddTarget.js
@@ -297,9 +297,12 @@ module.exports = function (context) {
       if (typeof configurations[key].buildSettings !== 'undefined') {
         var buildSettingsObj = configurations[key].buildSettings;
         if (typeof buildSettingsObj['PRODUCT_NAME'] !== 'undefined') {
-          buildSettingsObj['CODE_SIGN_ENTITLEMENTS'] = '"ShareExtension/ShareExtension-Entitlements.plist"';
           var productName = buildSettingsObj['PRODUCT_NAME'];
+          // Only patch the ShareExt target. Previously CODE_SIGN_ENTITLEMENTS
+          // was assigned unconditionally, which clobbered the main app's
+          // entitlements (push, associated domains, keychain sharing, ...).
           if (productName.indexOf('ShareExt') >= 0) {
+            buildSettingsObj['CODE_SIGN_ENTITLEMENTS'] = '"ShareExtension/ShareExtension-Entitlements.plist"';
             buildSettingsObj['PRODUCT_BUNDLE_IDENTIFIER'] = bundleIdentifier+BUNDLE_SUFFIX;
           }
         }


### PR DESCRIPTION
## Problem

`hooks/iosAddTarget.js` walked every build configuration in the Xcode project and unconditionally assigned `CODE_SIGN_ENTITLEMENTS` to `ShareExtension/ShareExtension-Entitlements.plist`. Because the loop touched the **main app target** too, the plugin silently destroyed any entitlements already configured on it (push notifications, associated domains, keychain sharing, etc.) on every install or platform rebuild.

Reported in #99, still present at v2.1.0. This is the fix that @BenjaminPoncet attempted in #97 but left incomplete.

## Fix

Move the `CODE_SIGN_ENTITLEMENTS` assignment inside the existing `productName.indexOf('ShareExt') >= 0` gate, matching the adjacent `PRODUCT_BUNDLE_IDENTIFIER` logic. Main target build settings are now untouched.

## Before

```js
if (typeof buildSettingsObj['PRODUCT_NAME'] !== 'undefined') {
  buildSettingsObj['CODE_SIGN_ENTITLEMENTS'] = '"ShareExtension/ShareExtension-Entitlements.plist"';
  var productName = buildSettingsObj['PRODUCT_NAME'];
  if (productName.indexOf('ShareExt') >= 0) {
    buildSettingsObj['PRODUCT_BUNDLE_IDENTIFIER'] = bundleIdentifier+BUNDLE_SUFFIX;
  }
}
```

## After

```js
if (typeof buildSettingsObj['PRODUCT_NAME'] !== 'undefined') {
  var productName = buildSettingsObj['PRODUCT_NAME'];
  if (productName.indexOf('ShareExt') >= 0) {
    buildSettingsObj['CODE_SIGN_ENTITLEMENTS'] = '"ShareExtension/ShareExtension-Entitlements.plist"';
    buildSettingsObj['PRODUCT_BUNDLE_IDENTIFIER'] = bundleIdentifier+BUNDLE_SUFFIX;
  }
}
```

## Test plan

- [ ] Install plugin on a project whose main app target already has `CODE_SIGN_ENTITLEMENTS` pointing at `MyApp/MyApp.entitlements` (e.g. with push notifications enabled).
- [ ] Confirm `project.pbxproj` after install still shows `CODE_SIGN_ENTITLEMENTS = MyApp/MyApp.entitlements;` on the main target.
- [ ] Confirm the ShareExt target's build config has `CODE_SIGN_ENTITLEMENTS = "ShareExtension/ShareExtension-Entitlements.plist";` as before.

Closes #99.