### PR TITLE
Fix #89: make plugin variables optional so uninstall works

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -41,8 +41,12 @@ SOFTWARE.
 
     <!-- ios -->
     <platform name="ios">
-        <preference name="IOS_URL_SCHEME" />
-        <preference name="IOS_UNIFORM_TYPE_IDENTIFIER" />
+        <!-- defaults make these preferences optional, so `cordova plugin rm`
+             works without the caller having to re-supply every variable. The
+             install-time hooks still pick up user-provided values via
+             --variable / package.json when present. See #89. -->
+        <preference name="IOS_URL_SCHEME" default="openwith" />
+        <preference name="IOS_UNIFORM_TYPE_IDENTIFIER" default="public.data" />
 
         <js-module src="www/openwith.js" name="openwith">
             <clobbers target="cordova.openwith" />
@@ -86,7 +90,7 @@ SOFTWARE.
     <!-- android -->
     <platform name="android">
 
-        <preference name="ANDROID_MIME_TYPE" />
+        <preference name="ANDROID_MIME_TYPE" default="*/*" />
         <preference name="ANDROID_EXTRA_ACTIONS" default=" " />
 
         <js-module src="www/openwith.js" name="openwith">


### PR DESCRIPTION
## Problem

`cordova plugin rm cc.fovea.cordova.openwith` failed with `Variable(s) missing: ANDROID_MIME_TYPE`, and re-supplying the variables just produced different missing-variable errors. End result: the plugin was effectively unremovable without manual surgery across `package.json`, `config.xml`, and the Xcode project.

Reported in #89, still reproducible with Cordova 12 / cordova-ios 7.

## Root cause

The `<preference>` entries in `plugin.xml` had no `default=` attribute. Cordova treats those as required for **both** install and uninstall — which is why uninstall demands the same variable list, even though the values are irrelevant to the removal path.

## Fix

Add sensible defaults to each required preference:

- `ANDROID_MIME_TYPE` → `*/*`
- `IOS_URL_SCHEME` → `openwith`
- `IOS_UNIFORM_TYPE_IDENTIFIER` → `public.data`

`ANDROID_EXTRA_ACTIONS` already had `default=" "`.

User-provided values still take precedence via the existing `--variable` / `package.json` flow, so this is fully backwards compatible. Projects that pin variables continue to work unchanged; projects that don't can now remove the plugin.

## Test plan

- [ ] `cordova plugin add cc.fovea.cordova.openwith --variable ANDROID_MIME_TYPE="image/*" --variable IOS_URL_SCHEME=myscheme --variable IOS_UNIFORM_TYPE_IDENTIFIER=public.image` — confirm user values still end up in `package.json` and in the generated `AndroidManifest.xml` / `CFBundleURLSchemes`.
- [ ] `cordova plugin rm cc.fovea.cordova.openwith` — confirm it completes without `Variable(s) missing`.

Closes #89.