### PR TITLE
Fix #106/#94: wake host app from share extension reliably

### DIFF
--- a/src/ios/OpenWithPlugin.m
+++ b/src/ios/OpenWithPlugin.m
@@ -137,6 +137,15 @@ static NSDictionary* launchOptions = nil;
 
     // [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(onPause) name:UIApplicationDidEnterBackgroundNotification object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(onResume) name:UIApplicationWillEnterForegroundNotification object:nil];
+
+    // Also wake on DidBecomeActive and on Cordova's openURL notification.
+    // Without these, the host app never picks up a fresh share when:
+    //   - it was already foregrounded when the user hit Post (#94), or
+    //   - it is brought forward via the ShareExt URL scheme while the OS
+    //     does not fire WillEnterForeground (#106).
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(onResume) name:UIApplicationDidBecomeActiveNotification object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(onHandleOpenURL:) name:CDVPluginHandleOpenURLNotification object:nil];
+
     // [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(onOrientationWillChange) name:UIApplicationWillChangeStatusBarOrientationNotification object:nil];
     // [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(onOrientationDidChange) name:UIApplicationDidChangeStatusBarOrientationNotification object:nil];
 
@@ -164,6 +173,13 @@ static NSDictionary* launchOptions = nil;
 
 - (void) onResume {
     [self debug:@"[onResume]"];
+    [self checkForFileToShare];
+}
+
+- (void) onHandleOpenURL:(NSNotification*)notification {
+    // Cordova posts this when the host app is launched (or re-foregrounded)
+    // via a URL scheme — including the scheme the ShareExt uses to wake us.
+    [self debug:@"[onHandleOpenURL]"];
     [self checkForFileToShare];
 }
 


### PR DESCRIPTION
## Problem

After a user hits Post in the share extension, the host app never picks up the shared item until it is manually force-quit and reopened. Two distinct failure modes:

- **#94**: the host app is already in the foreground when the user taps Share → Post. The ShareExt writes to the shared container but `checkForFileToShare` never runs, so the JS handler never fires.
- **#106**: the host app is backgrounded, the ShareExt opens the URL scheme to wake it, but iOS does not always post `UIApplicationWillEnterForegroundNotification` — particularly on newer iOS versions when the app is already in memory — so the handler still never fires.

Both reports are still present at v2.1.0.

## Root cause

`OpenWithPlugin.m:pluginInitialize` only observed `UIApplicationWillEnterForegroundNotification`. That single signal doesn't cover either scenario above.

## Fix

Observe two additional notifications, both of which call the existing idempotent `checkForFileToShare`:

1. **`UIApplicationDidBecomeActiveNotification`** — fires whenever the app regains focus, including the URL-scheme wake path that `WillEnterForeground` misses.
2. **`CDVPluginHandleOpenURLNotification`** — Cordova posts this when the AppDelegate receives the URL scheme that the ShareExt's `openURL:` sends. Fires even when the app was already foregrounded, closing the #94 gap.

`checkForFileToShare` already no-ops when the shared container is empty, so the extra observers are safe and won't cause double-delivery — the method pulls-and-clears the `@"image"` key atomically via `removeObjectForKey:`.

## Test plan

- [ ] App in background, share an image to it from Photos → handler fires on wake, no manual reopen required.
- [ ] App already foregrounded, take a screenshot and share it to the same app → handler fires.
- [ ] Cold-start share (app not running) → handler still fires once JS initializes, same as before.
- [ ] Share twice in a row without closing the app → second share's handler fires, no stale data from the first.

Closes #106 and #94.