### PR TITLE
Fix #66: populate App Groups in Release entitlements too

### DIFF
--- a/hooks/iosAddTarget.js
+++ b/hooks/iosAddTarget.js
@@ -150,6 +150,39 @@ function projectPlistJson(context, projectName) {
   return plist.parse(fs.readFileSync(path, 'utf8'));
 }
 
+// Merge the App Group identifier into the main app's entitlements files.
+// Cordova generates separate Entitlements-Debug.plist and Entitlements-Release.plist
+// in platforms/ios/<ProjectName>/. Previously we only wired App Groups into the
+// Debug file via Xcode's automatic signing; Release builds shipped without the
+// capability and the ShareExt could not talk to the host app. See #66.
+function addAppGroupToMainEntitlements(context, projectName, groupIdentifier) {
+  var plist = require('plist');
+  var configs = ['Entitlements-Debug.plist', 'Entitlements-Release.plist'];
+  var APP_GROUPS_KEY = 'com.apple.security.application-groups';
+
+  configs.forEach(function(fileName) {
+    var filePath = path.join(iosFolder(context), projectName, fileName);
+    if (!fs.existsSync(filePath)) {
+      console.log('    Skipping ' + fileName + ' (not present).');
+      return;
+    }
+    var contents;
+    try {
+      contents = plist.parse(fs.readFileSync(filePath, 'utf8'));
+    } catch (e) {
+      console.log('    Could not parse ' + fileName + ': ' + e.message);
+      return;
+    }
+    var groups = contents[APP_GROUPS_KEY] || [];
+    if (groups.indexOf(groupIdentifier) < 0) {
+      groups.push(groupIdentifier);
+      contents[APP_GROUPS_KEY] = groups;
+      fs.writeFileSync(filePath, plist.build(contents));
+      console.log('    Added App Group to ' + fileName + '.');
+    }
+  });
+}
+
 function getPreferences(context, configXml, projectName) {
   var plist = projectPlistJson(context, projectName);
   var group = "group." + bundleIdentifier + BUNDLE_SUFFIX;
@@ -240,6 +273,10 @@ module.exports = function (context) {
     // printShareExtensionFiles(files);
 
     var preferences = getPreferences(context, configXml, projectName);
+    var groupIdentifier = preferences.filter(function(p) { return p.key === '__GROUP_IDENTIFIER__'; })[0];
+    if (groupIdentifier && groupIdentifier.value) {
+      addAppGroupToMainEntitlements(context, projectName, groupIdentifier.value);
+    }
     files.plist.concat(files.source).forEach(function(file) {
       replacePreferencesInFile(file.path, preferences);
       // console.log('    Successfully updated ' + file.name);


### PR DESCRIPTION
## Problem

`cordova build ios --release` produced archives where the main app had no App Groups entitlement. At runtime the ShareExt could no longer see the shared container, and the host app's handler silently never fired — which is exactly the "works on my phone, broken on TestFlight" pattern widely reported in the issue tracker (confirmed in #66 and echoes through #25 / #36 / #95).

## Root cause

Cordova generates **two** entitlements files per iOS project:

- `platforms/ios/<ProjectName>/Entitlements-Debug.plist`
- `platforms/ios/<ProjectName>/Entitlements-Release.plist`

The plugin's install hook only caused App Groups to be wired into the Debug file (indirectly, via Xcode's automatic signing for dev builds). The Release file was never touched, so distribution archives shipped without `com.apple.security.application-groups`.

## Fix

Add an `addAppGroupToMainEntitlements(...)` helper in `hooks/iosAddTarget.js` that:

- Loads **both** Debug and Release entitlements files,
- Parses each with the existing `plist` module,
- Merges the resolved App Group identifier (the one the ShareExt already uses — honors `IOS_GROUP_IDENTIFIER` if set) into `com.apple.security.application-groups`,
- Writes the file back.

Properties:

- **Idempotent** — skips the write if the group is already present.
- **Non-fatal on missing files** — older project layouts (or non-standard entitlements file names) are just logged and skipped, not treated as errors.
- **Non-destructive** — merges into any existing App Groups list rather than replacing it, so apps that already use App Groups for other extensions keep working.

Wires into the existing install flow right after `getPreferences(...)` resolves the group identifier.

## Test plan

- [ ] Install plugin on a fresh project. Inspect both `Entitlements-*.plist` files → both now contain `com.apple.security.application-groups` with the expected `group.<bundleid>.shareextension` entry.
- [ ] Install on a project that already has App Groups configured for another extension → the existing groups are preserved and our group is appended.
- [ ] `cordova build ios --release` → archive ships with App Groups on the main app; ShareExt handler fires end-to-end on a TestFlight build.
- [ ] Re-run `cordova prepare` multiple times → entitlements files don't grow duplicate entries (idempotence check).

Closes #66.