### PR TITLE
Fix #79: spool share payload to App Group container, not NSUserDefaults

### DIFF
--- a/src/ios/OpenWithPlugin.m
+++ b/src/ios/OpenWithPlugin.m
@@ -227,11 +227,30 @@ static NSDictionary* launchOptions = nil;
         return;
     }
     NSDictionary *dict = (NSDictionary*)object;
-    NSData *data = dict[@"data"];
     NSString *text = dict[@"text"];
     NSString *name = dict[@"name"];
     self.backURL = dict[@"backURL"];
     NSString *type = [self mimeTypeFromUti:dict[@"uti"]];
+
+    // Prefer the spooled file path written by ShareViewController.m. Fall
+    // back to inline @"data" for backwards compatibility with older
+    // ShareExt builds and for the small-payload path. See #79.
+    NSData *data = nil;
+    NSString *dataPath = dict[@"dataPath"];
+    if ([dataPath isKindOfClass:NSString.class] && dataPath.length > 0) {
+        NSURL *fileURL = [NSURL fileURLWithPath:dataPath];
+        NSError *readError = nil;
+        data = [NSData dataWithContentsOfURL:fileURL options:0 error:&readError];
+        if (data == nil) {
+            [self debug:[NSString stringWithFormat:@"[checkForFileToShare] Failed to read spooled payload: %@", readError]];
+        }
+        // Clean up the spooled file regardless of read success so we
+        // don't leak files in the shared container.
+        [[NSFileManager defaultManager] removeItemAtURL:fileURL error:nil];
+    } else {
+        data = dict[@"data"];
+    }
+
     if (![data isKindOfClass:NSData.class] || ![text isKindOfClass:NSString.class]) {
         [self debug:@"[checkForFileToShare] Data content is invalid"];
         return;

--- a/src/ios/ShareExtension/ShareViewController.m
+++ b/src/ios/ShareExtension/ShareViewController.m
@@ -129,7 +129,7 @@
             [self debug:[NSString stringWithFormat:@"item provider = %@", itemProvider]];
             
             [itemProvider loadItemForTypeIdentifier:SHAREEXT_UNIFORM_TYPE_IDENTIFIER options:nil completionHandler: ^(id<NSSecureCoding> item, NSError *error) {
-                
+
                 NSData *data = [[NSData alloc] init];
                 if([(NSObject*)item isKindOfClass:[NSURL class]]) {
                     data = [NSData dataWithContentsOfURL:(NSURL*)item];
@@ -152,14 +152,40 @@
                 else {
                     uti = SHAREEXT_UNIFORM_TYPE_IDENTIFIER;
                 }
-                NSDictionary *dict = @{
+
+                // Spool the payload to a file in the App Group container
+                // instead of storing the raw bytes in NSUserDefaults.
+                // iOS 13+ caps CFPreferences/NSUserDefaults at 4MB per
+                // domain; anything larger throws and corrupts the suite
+                // until the app is force-quit. See #79.
+                NSString *dataPath = nil;
+                NSURL *containerURL = [[NSFileManager defaultManager] containerURLForSecurityApplicationGroupIdentifier:SHAREEXT_GROUP_IDENTIFIER];
+                if (containerURL != nil && data.length > 0) {
+                    NSString *fileName = [[NSUUID UUID] UUIDString];
+                    NSURL *dataFileURL = [containerURL URLByAppendingPathComponent:fileName];
+                    NSError *writeError = nil;
+                    if ([data writeToURL:dataFileURL options:NSDataWritingAtomic error:&writeError]) {
+                        dataPath = [dataFileURL path];
+                    } else {
+                        [self debug:[NSString stringWithFormat:@"[didSelectPost] Failed to spool payload: %@", writeError]];
+                    }
+                }
+
+                NSMutableDictionary *dict = [@{
                     @"text": self.contentText,
                     @"backURL": self.backURL,
-                    @"data" : data,
                     @"uti": uti,
                     @"utis": utis,
                     @"name": suggestedName
-                };
+                } mutableCopy];
+                if (dataPath != nil) {
+                    dict[@"dataPath"] = dataPath;
+                } else {
+                    // Fall back to inline bytes for tiny payloads where
+                    // the container URL wasn't available. Keeps behavior
+                    // unchanged for the happy-path small-file case.
+                    dict[@"data"] = data;
+                }
                 [self.userDefaults setObject:dict forKey:@"image"];
                 [self.userDefaults synchronize];
 


### PR DESCRIPTION
## Problem

Sharing any file larger than ~4MB into a cordova-plugin-openwith app on iOS 13+ produces this console error, corrupts the shared `NSUserDefaults` suite, and leaves the ShareExt permanently dead until the host app is force-quit and relaunched:

```
[User Defaults] CFPrefsPlistSource<0x…> ... Attempting to store >= 4194304
bytes of data in CFPreferences/NSUserDefaults on this platform is invalid.
This is a bug in <app> or a library it uses.
```

Reported in #79 (and the related #71 "App Crashes while selecting large file"). Still present at v2.1.0. Hits any app whose users share photos, PDFs, videos — essentially anything non-trivial.

## Root cause

`ShareViewController.m` put the entire file payload directly into the shared `NSUserDefaults` suite:

```objc
NSDictionary *dict = @{
    @"text": self.contentText,
    @"data" : data,    // <-- raw file bytes
    ...
};
[self.userDefaults setObject:dict forKey:@"image"];
```

iOS 13 added a hard 4MB cap on `CFPreferences/NSUserDefaults` per domain, which the plugin silently exceeds for anything but small thumbnails.

## Fix

Write the payload to a file in the App Group shared container and store only the resolved path in `NSUserDefaults`. The suite now carries a few hundred bytes of metadata regardless of the payload size, so the 4MB cap is no longer in the hot path.

**`ShareViewController.m`**:

- Resolve the shared container via `containerURLForSecurityApplicationGroupIdentifier:SHAREEXT_GROUP_IDENTIFIER`.
- Write the payload to a UUID-named file (atomic write).
- Store the file path under `@"dataPath"`.
- Gracefully fall back to the legacy `@"data"` inline key if the container URL isn't available, so existing small-payload behavior is unchanged.

**`OpenWithPlugin.m` → `checkForFileToShare`**:

- Prefer `@"dataPath"` when present: read the file, then `removeItemAtURL:` regardless of success so we never leak spool files.
- Fall back to the legacy `@"data"` key when `dataPath` is absent — keeps older ShareExt builds (before this PR lands) fully compatible with the updated host code and vice versa.

## Test plan

- [ ] Share a small (<1MB) image from Photos → works exactly as before (regression check for the small-file path).
- [ ] Share a >5MB PDF from Files → handler fires with the full payload; no `4194304 bytes` error in console.
- [ ] Share a >20MB video → handler fires, shared container has no leftover files afterward (`ls ~/Library/Group\ Containers/...` via simulator).
- [ ] Share twice in a row — confirm the spool file from the first share is gone before the second write.

Closes #79.