### PR TITLE
fix(plugin.xml): XML comment must not contain `--` (breaks Cordova parse on 2.2.0)

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -43,8 +43,8 @@ SOFTWARE.
     <platform name="ios">
         <!-- defaults make these preferences optional, so `cordova plugin rm`
              works without the caller having to re-supply every variable. The
-             install-time hooks still pick up user-provided values via
-             --variable / package.json when present. See #89. -->
+             install-time hooks still pick up user-provided values via CLI
+             variables and package.json when present. See #89. -->
         <preference name="IOS_URL_SCHEME" default="openwith" />
         <preference name="IOS_UNIFORM_TYPE_IDENTIFIER" default="public.data" />
 


### PR DESCRIPTION
## Problem

In `plugin.xml` (v2.2.0), the multi-line comment added for #89 includes the literal text `--variable`. **XML 1.0** forbids the substring `--` inside `<!-- ... -->` (except in `-->`). Strict XML parsers (used by Cordova / elementtree / sax) fail with **Malformed comment**, breaking **`cordova platform add`** on Android and elsewhere.

## Fix

Reword the comment to describe the same behaviour (**CLI variables** + `package.json`) without the forbidden sequence.

## Notes

- No functional change to preferences or hooks; comment text only.
- See also: npm `cc.fovea.cordova.openwith@2.2.0` published 2026-04-17.

Fixes downstream installs until maintainers can ship 2.2.1.

Made with [Cursor](https://cursor.com)